### PR TITLE
a11y improvements

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,8 @@
 import VShareTools from '/v2/src/components/VShareTools.vue'
 import VShareToolsItem from '/v2/src/components/VShareToolsItem.vue'
 import VFlexibleLink from '/v2/src/components/VFlexibleLink.vue'
-import VCard from '~~/v2/src/components/VCard.vue'
+import VCard from '/v2/src/components/VCard.vue'
+import VImageWithCaption from '/v2/src/components/VImageWithCaption.vue'
 import Home from '/src/components/Home.vue'
 import { onBeforeMount, ref } from 'vue'
 </script>
@@ -41,19 +42,33 @@ import { onBeforeMount, ref } from 'vue'
             <div class="grid">
               <div class="col-12 p-fluid">
                 <div class="card">
-                  <h5>Cards</h5>
+                  <h5>Card</h5>
                   <v-card
                     image="https://cms.demo.nypr.digital/images/212141/fill-%width%x%height%|format-jpeg|jpegquality-%quality%/"
                     title="Title with some <em>HTML</em>"
-                    titleLink="https://www.google.com"
+                    title-link="https://www.google.com"
                     subtitle="Subtitle"
                     :width="175"
                     :tags="[{name: 'tag', slug: 'tag'}]"
                     :height="175"
-                    :maxWidth="1440"
-                    :maxHeight="2560">
+                    :max-width="1440"
+                    :max-height="2560">
                     <a href="https://primefaces.org/primevue/showcase/#/icons">Get icons here</a>
                   </v-card>
+                </div>
+                <div class="card">
+                  <h5>Image With Caption</h5>
+                  <v-image-with-caption
+                    alt-text="Fallback alt text here"
+                    image="https://cms.prod.nypr.digital/images/328822/fill-%width%x%height%|format-jpeg|jpegquality-%quality%/"
+                    caption="Caption Here"
+                    credit="Credit Text Here"
+                    credit-url="https://www.Credit-URL-Here.com"
+                    title='Title Text Here'
+                    description='Description Text Here'
+                    :width="600"
+                    :height="400"
+                  />
                 </div>
               </div>
             </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,7 +19,6 @@ import { onBeforeMount, ref } from 'vue'
                 ><a href="#darkmode">jump to DARK MODE</a></span
               >
             </h1>
-
             <v-share-tools>
               <v-share-tools-item
                 service="site"
@@ -38,6 +37,25 @@ import { onBeforeMount, ref } from 'vue'
             >
             <br />
             <br />
+
+            <div class="grid">
+              <div class="col-12 p-fluid">
+                <div class="card">
+                  <h5>Cards</h5>
+                  <v-card
+                    image="https://cms.demo.nypr.digital/images/212141/fill-%width%x%height%|format-jpeg|jpegquality-%quality%/"
+                    title:="Title with some <em>HTML</em>"
+                    titleLink="https://www.google.com"
+                    subtitle="Subtitle"
+                    :width="175"
+                    :height="175"
+                    :maxWidth="1440"
+                    :maxHeight="2560">
+                    <a href="https://primefaces.org/primevue/showcase/#/icons">Get icons here</a>
+                  </v-card>
+                </div>
+              </div>
+            </div>
             <client-only>
               <home />
             </client-only>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -44,10 +44,11 @@ import { onBeforeMount, ref } from 'vue'
                   <h5>Cards</h5>
                   <v-card
                     image="https://cms.demo.nypr.digital/images/212141/fill-%width%x%height%|format-jpeg|jpegquality-%quality%/"
-                    title:="Title with some <em>HTML</em>"
+                    title="Title with some <em>HTML</em>"
                     titleLink="https://www.google.com"
                     subtitle="Subtitle"
                     :width="175"
+                    :tags="[{name: 'tag', slug: 'tag'}]"
                     :height="175"
                     :maxWidth="1440"
                     :maxHeight="2560">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,6 +2,7 @@
 import VShareTools from '/v2/src/components/VShareTools.vue'
 import VShareToolsItem from '/v2/src/components/VShareToolsItem.vue'
 import VFlexibleLink from '/v2/src/components/VFlexibleLink.vue'
+import VCard from '~~/v2/src/components/VCard.vue'
 import Home from '/src/components/Home.vue'
 import { onBeforeMount, ref } from 'vue'
 </script>

--- a/v2/src/components/VCard.vue
+++ b/v2/src/components/VCard.vue
@@ -167,7 +167,8 @@ const hasDetails = computed(() => {
           class="card-image w-full"
           :class="responsive ? `${bp}:hidden ${bp}:w-max` : 'hidden'"
           :image="image"
-          :alt-text="alt"
+          alt-text=""
+          is-decorative
           :loading="loading"
           :image-url="titleLink"
           :width="width ? Math.round(width * props.mobileImageScale) : null"
@@ -188,7 +189,8 @@ const hasDetails = computed(() => {
           class="card-image w-full"
           :class="{ [`hidden ${bp}:w-max ${bp}:block`]: responsive }"
           :image="image"
-          :alt-text="alt"
+          alt-text=""
+          is-decorative
           :loading="loading"
           :image-url="titleLink"
           :width="width ? Math.round(width * props.mobileImageScale) : null"

--- a/v2/src/components/VImageWithCaption.vue
+++ b/v2/src/components/VImageWithCaption.vue
@@ -138,6 +138,14 @@ const props = defineProps({
       return [2, 3]
     },
   },
+  /** * Use to indicate decorative images with a link, where the exact same link is repeated in nearby text.
+  e.g. A thumbnail that links to an article next to a title that links to the same article.
+  WARNING: This will make the link unreachable by assistive software so only use this for truly redundant links.
+  */
+  isDecorative: {
+    type: Boolean,
+    default: false
+  }
 })
 
 const emit = defineEmits([
@@ -209,7 +217,8 @@ const getCurrentDimensions = computed(() => {
           :class="!imageUrl && !allowPreview ? 'disabled' : ''"
           :to="imageUrl && !allowPreview ? imageUrl : null"
           target="_blank"
-          aria-hidden="true"
+          :aria-hidden="isDecorative ? true : false"
+          :tabIndex="isDecorative ? -1 : 0"
           @click="
             imageUrl && !allowPreview ? emit('image-click', imageUrl) : null
           "
@@ -217,7 +226,7 @@ const getCurrentDimensions = computed(() => {
           <v-simple-responsive-image
             v-if="(image && thisWidth) || width"
             :src="image"
-            :alt="altText"
+            :alt="isDecorative ? '' : altText"
             :loading="loading"
             :width="width ? width : getCurrentDimensions.width"
             :height="height ? height : getCurrentDimensions.height"

--- a/v2/src/components/VImageWithCaption.vue
+++ b/v2/src/components/VImageWithCaption.vue
@@ -218,7 +218,7 @@ const getCurrentDimensions = computed(() => {
           :to="imageUrl && !allowPreview ? imageUrl : null"
           target="_blank"
           :aria-hidden="isDecorative ? true : false"
-          :tabIndex="isDecorative ? -1 : 0"
+          :tab-index="isDecorative ? -1 : 0"
           @click="
             imageUrl && !allowPreview ? emit('image-click', imageUrl) : null
           "
@@ -250,6 +250,7 @@ const getCurrentDimensions = computed(() => {
             v-if="caption && captionVisible"
             class="image-with-caption-caption"
             :class="[{ 'keep-on-top': props.captionKeepOnTop }]"
+            aria-live="polite"
           >
             <p>{{ caption }}</p>
           </div>
@@ -262,11 +263,13 @@ const getCurrentDimensions = computed(() => {
       >
         <Button
           v-if="captionVisible"
+          aria-label="Hide Caption"
           icon="pi pi-times p-button-icon"
           class="p-button-sm p-button-secondary p-button-text image-with-caption-icons-close"
         ></Button>
         <Button
           v-else
+          aria-label="Show Caption"
           icon="pi pi-info"
           class="p-button-sm image-with-caption-icons-info"
         ></Button>

--- a/v2/src/components/VTag.vue
+++ b/v2/src/components/VTag.vue
@@ -21,18 +21,13 @@ const props = defineProps({
 <template>
   <span class="v-tag">
     <v-flexible-link
-      :to="props.slug"
-      :class="props.slug ? '' : 'disabled'"
-      class="raw"
+      :to="slug"
+      :class="slug ? '' : 'disabled'"
+      @click="slug ? emit('tagClick', slug) : null"
     >
-      <Button
-        :class="props.name"
-        :label="props.name"
-        :style="
-          props.radius !== null ? `border-radius: ${props.radius}px;` : ''
-        "
-        @click="props.slug ? emit('tagClick', props.slug) : null"
-      ></Button>
+      <div :class="`p-button p-button-rounded p-button-outlined ${name}`">
+        <span class="p-button-label">{{name}}</span>
+      </div>
     </v-flexible-link>
   </span>
 </template>
@@ -45,30 +40,29 @@ const props = defineProps({
     &.disabled {
       pointer-events: none;
     }
+    &:hover .p-button,
+    &:active .p-button {
+      background: var(--tag-hover-bg);
+      text-decoration: none !important;
+      .p-button-label {
+        color: var(--tag-hover-text-color) !important;
+        text-decoration: none !important;
+      }
+    }
     .p-button {
       padding: var(--tag-padding);
       border: var(--tag-border);
       border-radius: var(--tag-border-radius);
-      text-decoration: none;
+      text-decoration: none !important;
       vertical-align: middle;
       background: var(--tag-bg);
       color: var(--tag-text-color);
+      white-space: nowrap;
       .p-button-label {
         font-weight: var(--tag-font-weight);
         font-size: var(--tag-font-size);
         letter-spacing: var(--tag-letter-spacing);
         text-transform: uppercase;
-      }
-      &:link,
-      &:visited,
-      &:hover,
-      &:active {
-        background: var(--tag-hover-bg);
-        text-decoration: none !important;
-        .p-button-label {
-          color: var(--tag-hover-text-color) !important;
-          text-decoration: none !important;
-        }
       }
     }
   }


### PR DESCRIPTION
- Add a card and image with caption component to the nuxt preview app so we can see what changes look and sound like.
- Make sure the decorative thumbnail link doesn't show up as a redundant link for screen readers or keyboard users. (ideally there'd only be one link element but we can't do that here)
- Change the tag component so it doesn't use buttons wrapped in links, which show up twice on a screen reader (e.g. "Link, 'Donate'. Button, 'Donate'.) as well as needing to be tabbed through twice with keyboard nav.
- Add accessible names for the unlabeled show/hide caption button on the image-with-caption class, as well as adding an aria-live setting on the caption it self, so the browser will read it out loud when it's unhidden.
