### PR TITLE
accesibility fixes for image

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,6 +66,7 @@ import { onBeforeMount, ref } from 'vue'
                     credit-url="https://www.Credit-URL-Here.com"
                     title='Title Text Here'
                     description='Description Text Here'
+                    :allow-preview="true"
                     :width="600"
                     :height="400"
                   />

--- a/v2/src/components/VSimpleResponsiveImage.vue
+++ b/v2/src/components/VSimpleResponsiveImage.vue
@@ -216,6 +216,10 @@ const calcQuality = (quality, size) => {
 const enlarge = () => {
   loadingEnlargedImage.value = true
   const img = document.getElementsByClassName('p-image-preview')
+  img[0].setAttribute(
+    'alt',
+    props.alt
+  )
   if (rawImage) {
     img[0].setAttribute(
       'src',
@@ -268,6 +272,7 @@ const closeEnlarge = () => {
           <Button
             icon="pi pi-arrows-v"
             class="p-button-sm enlarge-button"
+            aria-label="Enlarge Image"
           ></Button>
         </template>
       </Image>


### PR DESCRIPTION
Add some accessibility improvements for the image lightbox.
- readable label on expand button
- alt text on expanded image.

But it will really need some major refactoring to be fully accessible. Right now the "modal" doesn't do anything to control focus, so while the image is blown up, keyboard navigation and screen readers just keep moving along the page behind the image.

As an aside, I'm not sure when this image component got turned into a full blown lightbox image magnifier rotator etc. component. This was supposed to just be what you might call in design system terms an "atom", just generating a better image tag that has responsive srcsets, that could be used as a building block for fancier components. That's why it's got simple in the name.  I really think the lightbox functionality would be better as part of its own component. 