### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/plugins/primevue.js
+++ b/plugins/primevue.js
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app"
+import { defineNuxtPlugin } from "#imports"
 import Accordion from 'primevue/accordion/accordion.esm.js'
 import AccordionTab from 'primevue/accordiontab/accordiontab.esm.js'
 import AutoComplete from 'primevue/autocomplete/autocomplete.esm.js'


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.